### PR TITLE
Uprev omegaup/go-base to v2

### DIFF
--- a/cmd/omegaup-logslurp/config.go
+++ b/cmd/omegaup-logslurp/config.go
@@ -14,12 +14,17 @@ type clientConfig struct {
 	URL string `json:"url"`
 }
 
+type loggingConfig struct {
+	JSON bool `json:"json,omitempty"`
+}
+
 type logslurpConfig struct {
 	Client           clientConfig             `json:"client"`
 	OffsetFilePath   string                   `json:"offset_file"`
 	StreamsDirectory string                   `json:"streams_directory,omitempty"`
 	Labels           map[string]string        `json:"labels"`
 	Streams          []*logslurp.StreamConfig `json:"streams,omitempty"`
+	Logging          loggingConfig            `json:"logging,omitempty"`
 }
 
 func readLogslurpConfig(configPath string) (*logslurpConfig, error) {

--- a/cmd/omegaup-logslurp/main.go
+++ b/cmd/omegaup-logslurp/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/inconshreveable/log15"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/logslurp"
 	"github.com/pkg/errors"
 )
@@ -233,14 +233,13 @@ func main() {
 		return
 	}
 
-	log := base.StderrLog()
-
 	config, err := readLogslurpConfig(*configPath)
 	if err != nil {
-		log.Error("failed to parse config", "err", err)
+		fmt.Printf("failed to parse config: %v", err)
 		os.Exit(1)
 	}
 
+	log := base.StderrLog(config.Logging.JSON)
 	if *singleFile != "" {
 		var streamConfig *logslurp.StreamConfig
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1
-	github.com/omegaup/go-base v1.0.1
+	github.com/omegaup/go-base/v2 v2.0.0
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -14,13 +13,11 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-github.com/omegaup/go-base v1.0.1 h1:7771a0jnJm4CPuK2lJxb56w03ASM1BkYLLfnYwhPagA=
-github.com/omegaup/go-base v1.0.1/go.mod h1:KRWOUExqxHkr/h1GiHEtAKGp4rx6mOGWsBSlN636INY=
+github.com/omegaup/go-base/v2 v2.0.0 h1:A4TGNKDbbAiF55EfxPh5r8knS/zDpFFJpFCYerqByzE=
+github.com/omegaup/go-base/v2 v2.0.0/go.mod h1:k5PYTZcULZt7Dbx67WI0Wk3WHJSMmyadEG1aWx6YbVg=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190520201301-c432e742b0af h1:NXfmMfXz6JqGfG3ikSxcz2N93j6DgScr19Oo2uwFu88=
-golang.org/x/sys v0.0.0-20190520201301-c432e742b0af/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab h1:FvshnhkKW+LO3HWHodML8kuVX8rnJTxKm9dFPuI68UM=
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tail_test.go
+++ b/tail_test.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"testing"
 
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 func TestTail(t *testing.T) {
@@ -25,7 +25,7 @@ func TestTail(t *testing.T) {
 		t.Errorf("Failed to create file: %v", err)
 	}
 
-	tail, err := NewTail(filename, 0, base.StderrLog())
+	tail, err := NewTail(filename, 0, base.StderrLog(false))
 	if err != nil {
 		t.Errorf("Failed to open file: %v", err)
 	}


### PR DESCRIPTION
This change uprevs omegaup/go-base to v2 to be able to emit logs in JSON
format. #minor